### PR TITLE
Chore: stop monitoring the Data Commons staging environment

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -23,8 +23,6 @@ sites:
     url: https://data.one.org
   - name: Data Commons
     url: https://datacommons.one.org
-  - name: Data Commons staging
-    url: https://datacommons.staging.one.org
   - name: ONE Recruiter
     url: https://recruiter.one.org/wp-login.php
   - name: Action Tracker


### PR DESCRIPTION
Not much to add here - just removes the Data Commons staging URL from the monitor config.